### PR TITLE
Fix: 修复空响应解析器

### DIFF
--- a/src/llm_models/model_client/gemini_client.py
+++ b/src/llm_models/model_client/gemini_client.py
@@ -288,26 +288,27 @@ def _default_normal_response_parser(
     """
     api_response = APIResponse()
 
-    if not hasattr(resp, "candidates") or not resp.candidates:
-        raise EmptyResponseException("响应解析失败，缺失candidates字段或candidates列表为空")
+    # 安全地解析思考内容
     try:
-        if resp.candidates[0].content and resp.candidates[0].content.parts:
-            for part in resp.candidates[0].content.parts:
-                if not part.text:
-                    continue
-                if part.thought:
-                    api_response.reasoning_content = (
-                        api_response.reasoning_content + part.text if api_response.reasoning_content else part.text
-                    )
+        if (candidates := getattr(resp, "candidates", None)) and candidates:
+            if candidates[0].content and candidates[0].content.parts:
+                for part in candidates[0].content.parts:
+                    if not part.text:
+                        continue
+                    if part.thought:
+                        api_response.reasoning_content = (
+                            api_response.reasoning_content + part.text if api_response.reasoning_content else part.text
+                        )
     except Exception as e:
         logger.warning(f"解析思考内容时发生错误: {e}，跳过解析")
 
-    if resp.text:
-        api_response.content = resp.text
+    # 安全地解析响应内容
+    api_response.content = getattr(resp, "text", None)
 
-    if resp.function_calls:
+    # 安全地解析工具调用
+    if function_calls := getattr(resp, "function_calls", None):
         api_response.tool_calls = []
-        for call in resp.function_calls:
+        for call in function_calls:
             try:
                 if not isinstance(call.args, dict):
                     raise RespParseException(resp, "响应解析失败，工具调用参数无法解析为字典类型")
@@ -317,19 +318,21 @@ def _default_normal_response_parser(
             except Exception as e:
                 raise RespParseException(resp, "响应解析失败，无法解析工具调用参数") from e
 
-    if resp.usage_metadata:
+    # 解析使用情况
+    if usage_metadata := getattr(resp, "usage_metadata", None):
         _usage_record = (
-            resp.usage_metadata.prompt_token_count or 0,
-            (resp.usage_metadata.candidates_token_count or 0) + (resp.usage_metadata.thoughts_token_count or 0),
-            resp.usage_metadata.total_token_count or 0,
+            usage_metadata.prompt_token_count or 0,
+            (usage_metadata.candidates_token_count or 0) + (usage_metadata.thoughts_token_count or 0),
+            usage_metadata.total_token_count or 0,
         )
     else:
         _usage_record = None
 
     api_response.raw_data = resp
 
+    # 最终的、唯一的空响应检查
     if not api_response.content and not api_response.tool_calls:
-        raise EmptyResponseException()
+        raise EmptyResponseException("响应中既无文本内容也无工具调用")
 
     return api_response, _usage_record
 


### PR DESCRIPTION
重构了 Gemini 客户端中的 `_default_normal_response_parser`，使其更健壮并纠正了一个逻辑缺陷。

此前实现存在两个问题：
1. 函数开头对 `resp.candidates` 的激进检查可能会错误地拒绝仅包含工具调用但缺少 `candidates` 字段的有效 API 响应。这引入了破坏现有功能的风险。
2. 直接属性访问（例如 `resp.text`）对结构不完整或格式错误的 API 响应不够健壮，存在 `AttributeError` 崩溃的风险。

本次提交通过以下方式解决了这些问题：
- 移除了过早且有风险的 `candidates` 检查。
- 使用 `getattr` 安全访问响应对象上的所有可选属性（`text`、`function_calls`、`usage_metadata` 等）。
- 依赖于一个单一的最终检查（`if not api_response.content and not api_response.tool_calls:`）作为判断空响应的唯一标准，这正确反映了业务逻辑。

这一更改直接解决了有效仅含工具调用的响应可能被不当丢弃的问题，同时使解析器普遍更能抵御意外的 API 响应结构。